### PR TITLE
Fix ajax redirect issue: 302 http status -> 401 status and put url into the body

### DIFF
--- a/src/main/java/com/example/keycloak_app/auth/LenasChangeLoginRedirectStrategyBeanPostProcessor.java
+++ b/src/main/java/com/example/keycloak_app/auth/LenasChangeLoginRedirectStrategyBeanPostProcessor.java
@@ -1,0 +1,57 @@
+package com.example.keycloak_app.auth;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+
+@Component
+public class LenasChangeLoginRedirectStrategyBeanPostProcessor implements BeanPostProcessor {
+
+    /**
+     * set private final redirect strategy to use custom 401 http status instead of 302
+     * to solve FE issue about impossible cross-domain redirect with 302 http status.
+     * due to https://github.com/spring-projects/spring-security/pull/11387
+     * set redirectStrategy in SpringSecurity can be done after Spring 5.8
+     * todo: delete this class after update Spring and setting IntraDefaultRedirectStrategy in SecurityConfig
+     */
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean.getClass() == DelegatingAuthenticationEntryPoint.class) {
+            Field entryPoints = null;
+            try {
+                entryPoints = DelegatingAuthenticationEntryPoint.class.getDeclaredField("entryPoints");
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+            entryPoints.setAccessible(true);
+            LinkedHashMap<RequestMatcher, AuthenticationEntryPoint> map = null;
+            try {
+                map = (LinkedHashMap<RequestMatcher, AuthenticationEntryPoint>) entryPoints.get(bean);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            var loginUrlAuthenticationEntryPoint = map.values().stream().findFirst().get();
+            LenasDefaultRedirectStrategy lenasDefaultRedirectStrategy = new LenasDefaultRedirectStrategy();
+            try {
+                setRedirectStrategy(loginUrlAuthenticationEntryPoint, lenasDefaultRedirectStrategy);
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return BeanPostProcessor.super.postProcessAfterInitialization(bean, beanName);
+    }
+
+    private void setRedirectStrategy(Object object, Object redirectStrategy) throws NoSuchFieldException, IllegalAccessException {
+        Field field = object.getClass().getDeclaredField("redirectStrategy");
+        field.setAccessible(true);
+        field.set(object, redirectStrategy);
+    }
+}

--- a/src/main/java/com/example/keycloak_app/auth/LenasDefaultRedirectStrategy.java
+++ b/src/main/java/com/example/keycloak_app/auth/LenasDefaultRedirectStrategy.java
@@ -25,7 +25,7 @@ public class LenasDefaultRedirectStrategy implements RedirectStrategy {
         }
         // for first AUTH redirect on {host}/Intra/oauth2/authorization/keycloak
         // to fix ajax cross-domain FE issue about impossible redirect by 302 http status
-        if (redirectUrl.contains("/oauth2/authorization/keycloak")) {
+        if (redirectUrl.contains("/oauth2/authorization/lenas-realm")) {
             response.setStatus(401);
             response.getWriter().write(redirectUrl);
             response.flushBuffer();

--- a/src/main/java/com/example/keycloak_app/auth/LenasDefaultRedirectStrategy.java
+++ b/src/main/java/com/example/keycloak_app/auth/LenasDefaultRedirectStrategy.java
@@ -1,0 +1,61 @@
+package com.example.keycloak_app.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+
+public class LenasDefaultRedirectStrategy implements RedirectStrategy {
+
+    protected final Log logger = LogFactory.getLog(this.getClass());
+    private boolean contextRelative;
+
+    @Override
+    public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
+        String redirectUrl = this.calculateRedirectUrl(request.getContextPath(), url);
+        redirectUrl = response.encodeRedirectURL(redirectUrl);
+        if (logger.isDebugEnabled()) {
+            logger.debug(LogMessage.format("Redirecting to %s", redirectUrl));
+        }
+        // for first AUTH redirect on {host}/Intra/oauth2/authorization/keycloak
+        // to fix ajax cross-domain FE issue about impossible redirect by 302 http status
+        if (redirectUrl.contains("/oauth2/authorization/keycloak")) {
+            response.setStatus(401);
+            response.getWriter().write(redirectUrl);
+            response.flushBuffer();
+        } else {
+            // for all other redirections should by default
+            response.sendRedirect(redirectUrl);
+        }
+    }
+
+    protected String calculateRedirectUrl(String contextPath, String url) {
+        if (!UrlUtils.isAbsoluteUrl(url)) {
+            return this.isContextRelative() ? url : contextPath + url;
+        } else if (!this.isContextRelative()) {
+            return url;
+        } else {
+            Assert.isTrue(url.contains(contextPath), "The fully qualified URL does not include context path.");
+            url = url.substring(url.lastIndexOf("://") + 3);
+            url = url.substring(url.indexOf(contextPath) + contextPath.length());
+            if (url.length() > 1 && url.charAt(0) == '/') {
+                url = url.substring(1);
+            }
+            return url;
+        }
+    }
+
+    public void setContextRelative(boolean useRelativeContext) {
+        this.contextRelative = useRelativeContext;
+    }
+
+    protected boolean isContextRelative() {
+        return this.contextRelative;
+    }
+}


### PR DESCRIPTION
fix ajax issue that they can not go by redirect HTTPs status code 302 on cross-domain urls, 
so redirect url put them into the response body with 401 